### PR TITLE
Mount host ~/.ssh as read-only in opencode-web container for git SSH …

### DIFF
--- a/composer/src/machine1.ts
+++ b/composer/src/machine1.ts
@@ -355,27 +355,27 @@ export default function machine1(): ComposeSpecification {
         },
       })),
 
-opencode: service("opencode-web", (helpers) => ({
-  image: "ghcr.io/schniz/opencode-web-bun:main",
-  container_name: "opencode-web",
-  networks: ["caddy"],
-  environment: [
-    "PUID=1000",
-    "PGID=1000",
-    "TZ=Asia/Jerusalem",
-    "PORT=3000",
-    "OPENCODE_WEB_REPOS_PATH=/repos",
-  ],
-  volumes: [
-    `${helpers.config}/auth.json:/root/.local/share/opencode/auth.json`,
-    `${LIBRARY_ROOT}/opencode/repos:/repos`,
-    `${LIBRARY_ROOT}/opencode/share:/root/.local/share/opencode/project`,
-    `${process.env.HOME || '/root'}/.ssh:/root/.ssh:ro`,
-  ],
-  labels: {
-    ...caddy.usingUpstreams("opencode", 3000),
-  },
-})),
+      opencode: service("opencode-web", (helpers) => ({
+        image: "ghcr.io/schniz/opencode-web-bun:main",
+        container_name: "opencode-web",
+        networks: ["caddy"],
+        environment: [
+          "PUID=1000",
+          "PGID=1000",
+          "TZ=Asia/Jerusalem",
+          "PORT=3000",
+          "OPENCODE_WEB_REPOS_PATH=/repos",
+        ],
+        volumes: [
+          `${helpers.config}/auth.json:/root/.local/share/opencode/auth.json`,
+          `${LIBRARY_ROOT}/opencode/repos:/repos`,
+          `${LIBRARY_ROOT}/opencode/share:/root/.local/share/opencode/project`,
+          `${process.env.HOME || "/root"}/.ssh:/root/.ssh:ro`,
+        ],
+        labels: {
+          ...caddy.usingUpstreams("opencode", 3000),
+        },
+      })),
       ...{
         tandoor_db: service("tandoor-db", (helpers) => ({
           image: "postgres:16-alpine",

--- a/composer/src/machine1.ts
+++ b/composer/src/machine1.ts
@@ -355,27 +355,27 @@ export default function machine1(): ComposeSpecification {
         },
       })),
 
-      opencode: service("opencode-web", (helpers) => ({
-        image: "ghcr.io/schniz/opencode-web-bun:main",
-        container_name: "opencode-web",
-        networks: ["caddy"],
-        environment: [
-          "PUID=1000",
-          "PGID=1000",
-          "TZ=Asia/Jerusalem",
-          "PORT=3000",
-          "OPENCODE_WEB_REPOS_PATH=/repos",
-        ],
-        volumes: [
-          `${helpers.config}/auth.json:/root/.local/share/opencode/auth.json`,
-          `${LIBRARY_ROOT}/opencode/repos:/repos`,
-          `${LIBRARY_ROOT}/opencode/share:/root/.local/share/opencode/project`,
-        ],
-        labels: {
-          ...caddy.usingUpstreams("opencode", 3000),
-        },
-      })),
-
+opencode: service("opencode-web", (helpers) => ({
+  image: "ghcr.io/schniz/opencode-web-bun:main",
+  container_name: "opencode-web",
+  networks: ["caddy"],
+  environment: [
+    "PUID=1000",
+    "PGID=1000",
+    "TZ=Asia/Jerusalem",
+    "PORT=3000",
+    "OPENCODE_WEB_REPOS_PATH=/repos",
+  ],
+  volumes: [
+    `${helpers.config}/auth.json:/root/.local/share/opencode/auth.json`,
+    `${LIBRARY_ROOT}/opencode/repos:/repos`,
+    `${LIBRARY_ROOT}/opencode/share:/root/.local/share/opencode/project`,
+    `${process.env.HOME || '/root'}/.ssh:/root/.ssh:ro`,
+  ],
+  labels: {
+    ...caddy.usingUpstreams("opencode", 3000),
+  },
+})),
       ...{
         tandoor_db: service("tandoor-db", (helpers) => ({
           image: "postgres:16-alpine",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,6 +385,7 @@ services:
       - /media/SchlezExt2/library/opencode/repos:/repos
       - >-
         /media/SchlezExt2/library/opencode/share:/root/.local/share/opencode/project
+      - /root/.ssh:/root/.ssh:ro
     labels:
       caddy_0: '*.home.hagever.com'
       caddy_0.tls.dns: cloudflare {env.CF_API_TOKEN}


### PR DESCRIPTION
…access

This allows the opencode-web service to use the host's SSH keys for secure git operations inside the container. No secrets are baked into the image; all credentials are mounted as read-only volumes for security.

🤖 Generated with [opencode](https://opencode.ai)